### PR TITLE
Add dns check in case it is set by env variables

### DIFF
--- a/hooks/sentry_hook.py
+++ b/hooks/sentry_hook.py
@@ -91,7 +91,7 @@ def get_dsn(conn):
     if None in (conn.conn_type, conn.login):
         return conn.host
 
-    dsn = f"{conn.conn_type}://{conn.login}@{conn.host}/{conn.schema}"
+    dsn = '{conn.conn_type}://{conn.login}@{conn.host}/{conn.schema}'.format(conn=conn)
     return dsn
 
 class SentryHook(BaseHook):

--- a/hooks/sentry_hook.py
+++ b/hooks/sentry_hook.py
@@ -87,13 +87,19 @@ def add_sentry(task_instance, *args, session=None, **kwargs):
             capture_exception()
             raise
 
+def get_dsn(conn):
+    if None in (conn.conn_type, conn.login):
+        return conn.host
+
+    dsn = f"{conn.conn_type}://{conn.login}@{conn.host}/{conn.schema}"
+    return dsn
 
 class SentryHook(BaseHook):
     """
     Wrap around the Sentry SDK.
     """
 
-    def __init__(self, sentry_conn_id=None):
+    def __init__(self, sentry_conn_id="sentry_dsn"):
         ignore_logger("airflow.task")
         ignore_logger("airflow.jobs.backfill_job.BackfillJob")
         executor_name = conf.get("core", "EXECUTOR")
@@ -108,13 +114,9 @@ class SentryHook(BaseHook):
             integrations += [sentry_celery]
 
         try:
-            conn_id = None
             dsn = None
-            if sentry_conn_id is None:
-                conn_id = self.get_connection("sentry_dsn")
-            else:
-                conn_id = self.get_connection(sentry_conn_id)
-            dsn = conn_id.host
+            conn = self.get_connection(sentry_conn_id)
+            dsn = get_dsn(conn)
             init(dsn=dsn, integrations=integrations)
         except (AirflowException, exc.OperationalError, exc.ProgrammingError):
             self.log.debug("Sentry defaulting to environment variable.")


### PR DESCRIPTION
Fix #15

Kept it backwards compatible, so if only a `conn.host` is provided, we just use the host. If we provide a `conn_type` and `login`, we create a `'{PROTOCOL}://{PUBLIC_KEY}@{HOST}/{PROJECT_ID}'` like we recommended in the README.