### PR TITLE
Add .gcloudignore

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -1,0 +1,7 @@
+.gcloudignore
+.git
+.gitignore
+.travis.yml
+requirements-test.txt
+tests/
+#!include:.gitignore


### PR DESCRIPTION
According to #18, we should avoid uploading test folders to Composer-based Airflow..