### PR TITLE
feat(APM): Add individual transaction to Airflow tasks

### DIFF
--- a/hooks/sentry_hook.py
+++ b/hooks/sentry_hook.py
@@ -6,13 +6,12 @@ from datetime import datetime
 from airflow import configuration as conf
 from airflow.exceptions import AirflowException
 from airflow.hooks.base_hook import BaseHook
-from airflow.models import TaskInstance, DagRun, XCom, Variable
+from airflow.models import TaskInstance, DagRun
 from airflow.utils.db import provide_session
 from airflow.utils.state import State
 
 import sentry_sdk
 from sentry_sdk.hub import Hub
-from sentry_sdk.tracing import Span
 from sentry_sdk.integrations.logging import ignore_logger
 from sentry_sdk.integrations.flask import FlaskIntegration
 from sentry_sdk.integrations.sqlalchemy import SqlalchemyIntegration
@@ -38,7 +37,9 @@ def get_task_instances(dag_id, task_ids, execution_date, session=None):
             TaskInstance.dag_id == dag_id,
             TaskInstance.task_id.in_(task_ids),
             TaskInstance.execution_date == execution_date,
-            or_(TaskInstance.state == State.SUCCESS, TaskInstance.state == State.FAILED),
+            or_(
+                TaskInstance.state == State.SUCCESS, TaskInstance.state == State.FAILED
+            ),
         )
         .all()
     )
@@ -49,7 +50,9 @@ def get_task_instances(dag_id, task_ids, execution_date, session=None):
 def get_dag_run(task_instance, session=None):
     dag_run = (
         session.query(DagRun)
-        .filter_by(dag_id=task_instance.dag_id, execution_date=task_instance.execution_date)
+        .filter_by(
+            dag_id=task_instance.dag_id, execution_date=task_instance.execution_date
+        )
         .first()
     )
 
@@ -94,167 +97,31 @@ def add_breadcrumbs(task_instance, session=None):
 
 
 @provide_session
-def get_unfinished_tasks(dag_run, session=None):
-    unfinished_tasks = dag_run.get_task_instances(
-        state=State.unfinished(),
-        session=session
-    )
-
-    return unfinished_tasks
-
-
-def date_json_serial(obj):
-    if isinstance(obj, datetime):
-        return obj.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
-    else:
-        return obj
-
-
-@provide_session
-def is_first_task(task_instance, dag_run, session=None):
-    all_tasks = dag_run.get_task_instances(session=session)
-    unfinished_tasks = get_unfinished_tasks(dag_run)
-
-    # Before first task, all tasks are unfinished
-    return len(all_tasks) == len(unfinished_tasks)
-
-
-def get_ids(task_instance, first_task, trace_key, span_key):
-    if first_task:
-        return uuid.uuid4().hex, uuid.uuid4().hex[16:]
-
-    return task_instance.xcom_pull(key=trace_key), task_instance.xcom_pull(key=span_key)
-
-
-@provide_session
 def sentry_patched_run_raw_task_with_span(task_instance, *args, session=None, **kwargs):
     """
     Create a scope for tagging and breadcrumbs in TaskInstance._run_raw_task.
     """
     hub = Hub.current
-    client = hub.client
-
+    # Avoid leaking tags by using push_scope.
     with hub.push_scope():
         dag_run = get_dag_run(task_instance)
+        task_id = task_instance.task_id
+        dag_id = task_instance.dag_id
         run_id = dag_run.run_id
-        current_task_id = task_instance.task_id
 
         add_tagging(task_instance, run_id)
-        add_breadcrumbs(task_instance)
-
-        trace_key = "__sentry_trace_id__" + run_id
-        span_key = "__sentry_span_id__" + run_id
-
-        first_task = is_first_task(task_instance, dag_run)
-        trace_id, parent_span_id = get_ids(
-            task_instance, first_task, trace_key, span_key
-        )
-
-        task_span = Span(
-            op="airflow-task",
-            description=current_task_id,
-            sampled=True,
-            trace_id=trace_id,
-            parent_span_id=parent_span_id,
-        )
-
+        add_breadcrumbs(task_instance, session)
         try:
-            with hub.start_span(task_span):
+            with hub.start_span(
+                op="airflow-task",
+                transaction="task_run: {} - {} - {}".format(
+                    task_id, dag_id, execution_date
+                ),
+            ):
                 original_run_raw_task(task_instance, *args, session=session, **kwargs)
         except Exception:
             hub.capture_exception()
             raise
-        finally:
-            dag_run = get_dag_run(task_instance)
-            task_ids = task_instance.task.dag.task_ids
-            execution_date = task_instance.execution_date
-            dag_id = task_instance.dag_id
-            unfinished_tasks = get_unfinished_tasks(dag_run)
-            dag_run_state = dag_run.state
-
-            transaction_span_key = "__sentry_parent_span" + run_id
-
-            if first_task:
-                transaction_span = Span(
-                    op="airflow-dag-run",
-                    transaction="dag_run: {} - {}".format(dag_id, execution_date),
-                    description=run_id,
-                    sampled=True,
-                    span_id=parent_span_id,
-                    trace_id=trace_id,
-                )
-
-                json_transaction_span = json.dumps(
-                    transaction_span.to_json(client), default=date_json_serial
-                )
-
-                task_instance.xcom_push(
-                    key=transaction_span_key, value=json_transaction_span
-                )
-                task_instance.xcom_push(key=trace_key, value=trace_id)
-                task_instance.xcom_push(key=span_key, value=parent_span_id)
-
-            if len(unfinished_tasks) and dag_run_state is not State.FAILED:
-                recorded_spans = [
-                    json.dumps(span.to_json(client), default=date_json_serial)
-                    for span in task_span._span_recorder.finished_spans
-                    if span is not None and task_span._span_recorder is not None
-                ]
-
-                task_span_key = "__sentry" + current_task_id + run_id
-                task_instance.xcom_push(key=task_span_key, value=recorded_spans)
-
-            # All tasks have finished or dag_run has failed
-            else:
-
-                def to_json_span(span):
-                    json_span = span.to_json(client)
-
-                    json_span["start_timestamp"] = json_span[
-                        "start_timestamp"
-                    ].strftime("%Y-%m-%dT%H:%M:%S.%fZ")
-                    json_span["timestamp"] = json_span["timestamp"].strftime(
-                        "%Y-%m-%dT%H:%M:%S.%fZ"
-                    )
-
-                    return json_span
-
-                last_recorded_spans = [
-                    to_json_span(span)
-                    for span in task_span._span_recorder.finished_spans
-                    if span is not None and task_span._span_recorder is not None
-                ]
-
-                for previous_task_id in task_ids:
-                    if previous_task_id is not current_task_id:
-                        previous_recorded_spans = task_instance.xcom_pull(
-                            key="__sentry" + previous_task_id + run_id,
-                            task_ids=previous_task_id,
-                        )
-
-                        if previous_recorded_spans:
-                            span = [
-                                json.loads(span)
-                                for span in previous_recorded_spans
-                                if span is not None
-                            ]
-
-                            last_recorded_spans.extend(span)
-
-                json_transaction_span = json.loads(
-                    task_instance.xcom_pull(key=transaction_span_key)
-                )
-
-                hub.capture_event(
-                    {
-                        "type": "transaction",
-                        "transaction": json_transaction_span["transaction"],
-                        "contexts": {"trace": get_trace_context(json_transaction_span)},
-                        "timestamp": datetime.now().strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
-                        "start_timestamp": json_transaction_span["start_timestamp"],
-                        "spans": last_recorded_spans,
-                    }
-                )
 
 
 @provide_session
@@ -277,23 +144,13 @@ def sentry_patched_run_raw_task(task_instance, *args, session=None, **kwargs):
             raise
 
 
-def get_trace_context(span):
-    rv = {
-        "trace_id": span['trace_id'],
-        "span_id": span['span_id'],
-        "parent_span_id": span['parent_span_id'],
-        "op": span['op'],
-        "description": span['description'],
-    }
-
-    return rv
-
 def get_dsn(conn):
     if None in (conn.conn_type, conn.login):
         return conn.host
 
-    dsn = '{conn.conn_type}://{conn.login}@{conn.host}/{conn.schema}'.format(conn=conn)
+    dsn = "{conn.conn_type}://{conn.login}@{conn.host}/{conn.schema}".format(conn=conn)
     return dsn
+
 
 class SentryHook(BaseHook):
     """
@@ -307,7 +164,11 @@ class SentryHook(BaseHook):
 
         integrations = [FlaskIntegration(), SqlalchemyIntegration()]
 
-        traces_sample_rate = 0.3 if os.environ.get('SENTRY_ENABLE_AIRFLOW_APM') in ["true", "True"] else 0
+        traces_sample_rate = (
+            1
+            if os.environ.get("SENTRY_ENABLE_AIRFLOW_APM") in ["true", "True"]
+            else 0
+        )
 
         if executor_name == "CeleryExecutor":
             from sentry_sdk.integrations.celery import CeleryIntegration
@@ -318,7 +179,12 @@ class SentryHook(BaseHook):
             dsn = None
             conn = self.get_connection(sentry_conn_id)
             dsn = get_dsn(conn)
-            sentry_sdk.init(dsn=dsn, integrations=integrations, traces_sample_rate=traces_sample_rate)
+            sentry_sdk.init(
+                dsn=dsn,
+                integrations=integrations,
+                traces_sample_rate=traces_sample_rate,
+            )
+
         except (AirflowException, exc.OperationalError, exc.ProgrammingError):
             self.log.debug("Sentry defaulting to environment variable.")
             sentry_sdk.init(integrations=integrations)

--- a/tests/test_sentry_hook.py
+++ b/tests/test_sentry_hook.py
@@ -46,6 +46,7 @@ CRUMB = {
     "level": "info",
 }
 
+
 class MockQuery:
     """
     Mock Query for when session is called.
@@ -66,6 +67,7 @@ class MockQuery:
 
     def delete(self):
         pass
+
 
 # TODO: Update to use pytest fixtures
 class TestSentryHook(unittest.TestCase):
@@ -131,7 +133,9 @@ class TestSentryHook(unittest.TestCase):
         """
         Test getting dsn from host, conn_type, login and schema
         """
-        conn = Connection(conn_type="http", login="bar", host="getsentry.io", schema="987")
+        conn = Connection(
+            conn_type="http", login="bar", host="getsentry.io", schema="987"
+        )
         dsn = get_dsn(conn)
         self.assertEqual(dsn, "http://bar@getsentry.io/987")
 
@@ -139,6 +143,8 @@ class TestSentryHook(unittest.TestCase):
         """
         Test getting dsn from host if other parameters are None
         """
-        conn = Connection(conn_type="http", login=None, host="https://foo@sentry.io/123")
+        conn = Connection(
+            conn_type="http", login=None, host="https://foo@sentry.io/123"
+        )
         dsn = get_dsn(conn)
         self.assertEqual(dsn, "https://foo@sentry.io/123")


### PR DESCRIPTION
Storing spans through XCom lead to database issues. As a temporary, we can associate each individual task to a transaction.

This way we can test with composer and get some benefit out of this.